### PR TITLE
Allow ergo-solution to accept one argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The arguments are all positional, but `name` is optional, meaning either of thes
 #theorem[ name ][ statement ][ proof ]
 ```
 
-If you wish to state a result without giving a proof, you can leave proof as an empty content block `[]`.
+If you wish to state a result without giving a proof, you can leave proof as an empty content block `[]`, or omit it altogether.
 
 All of these environments (regardless of type) share a set of (optional) keyword arguments, including `width` (default: `100%`) and `height` (default: `auto`), along with several other settings listed below.
 

--- a/src/main.typ
+++ b/src/main.typ
@@ -147,15 +147,15 @@
 
   if argc == 0 {
     panic("Must pass in at least one positional arguments")
-  } else if argc == 1{
+  } else if argc == 1 {
     statement-body = args.at(0)
-  } else if argc == 2{
+  } else if argc == 2 {
     statement-body = args.at(0)
-    solution-body = args.at(1)
-  } else if argc == 3{
-    title = args.at(0)
+    solution-body  = args.at(1)
+  } else if argc == 3 {
+    title          = args.at(0)
     statement-body = args.at(1)
-    solution-body = args.at(2)
+    solution-body  = args.at(2)
   } else {
     panic("Must pass in at most 3 positional arguments")
   }

--- a/src/main.typ
+++ b/src/main.typ
@@ -141,15 +141,24 @@
   let argc   = args.len()
   let kwargs = argv.named()  // passed to child function
 
-  if argc < 2 {
-    panic("Must pass in at least two positional arguments")
-  } else if argc > 3 {
+  let title = []
+  let statement-body = []
+  let solution-body = []
+
+  if argc == 0 {
+    panic("Must pass in at least one positional arguments")
+  } else if argc == 1{
+    statement-body = args.at(0)
+  } else if argc == 2{
+    statement-body = args.at(0)
+    solution-body = args.at(1)
+  } else if argc == 3{
+    title = args.at(0)
+    statement-body = args.at(1)
+    solution-body = args.at(2)
+  } else {
     panic("Must pass in at most 3 positional arguments")
   }
-
-  let title          = if argc == 3 {args.at(0)} else {[]}
-  let statement-body = if argc == 2 {args.at(0)} else {args.at(1)}
-  let solution-body  = if argc == 2 {args.at(1)} else {args.at(2)}
 
   let new-styles  = if valid-styles(styles) { styles } else { styles-state.get() }
   let new-colors  = if valid-colors(colors) { colors } else { colors-state.get() }

--- a/tests/all-envs.typ
+++ b/tests/all-envs.typ
@@ -1,5 +1,17 @@
 #import "@local/ergo:0.2.0": *
-#show: ergo-init.with(colors: ergo-colors.terracotta, styles: ergo-styles.tab1)
+#show: ergo-init.with(colors: ergo-colors.penumbra-light, styles: ergo-styles.tab2)
+
+#prob[
+  statement
+]
+
+#excs[
+  statement
+][]
+
+#sol[
+  sol
+]
 
 = Misc
 


### PR DESCRIPTION
When ergo-solution is given one argument, it is interpreted as a statement body, leaving the title and proof empty. 